### PR TITLE
📝 remove obsolete references to CII

### DIFF
--- a/best-practices-badge.md
+++ b/best-practices-badge.md
@@ -1,10 +1,10 @@
-# OpenSSF CII Best Practices Badge Guide
+# OpenSSF Best Practices Badge Guide
 
 ## Summary
 
-Ensuring the security, sustainability, and maintainability of software projects is critically important. Following industry-standard best practices is a great start to doing that, and the [OpenSSF CII Best Practices badge system][bp] is a reliable way to concretely audit and measure how well the project is doing.
+Ensuring the security, sustainability, and maintainability of software projects is critically important. Following industry-standard best practices is a great start to doing that, and the [OpenSSF Best Practices badge system][bp] is a reliable way to concretely audit and measure how well the project is doing.
 
-Here‘s how you can most efficiently secure your project and earn the OpenSSF CII Best Practices badge for your JS project - at a “Passing” level, at a minimum, and “Silver”, ideally. “Gold” is nice, but not practically achievable for most open source projects unless they are lucky or large enough to have multiple maintainers, or a corporation has intensely invested in them. To read more about the tiers, their rationale, and their goals, see [Criteria Discussion][bp-criteria].
+Here‘s how you can most efficiently secure your project and earn the OpenSSF Best Practices badge for your JS project - at a “Passing” level, at a minimum, and “Silver”, ideally. “Gold” is nice, but not practically achievable for most open source projects unless they are lucky or large enough to have multiple maintainers, or a corporation has intensely invested in them. To read more about the tiers, their rationale, and their goals, see [Criteria Discussion][bp-criteria].
 
 ## Who is this guide for?
 
@@ -179,7 +179,7 @@ That should cover the “passing” tier, and you should be at 100%.
 
 Make a PR. or push a commit, that adds the following markdown to the top of your readme:
 ```md
-[![CII Best Practices](https://www.bestpractices.dev/projects/$ID/badge)](https://www.bestpractices.dev/projects/$ID)
+[![Best Practices Badge](https://www.bestpractices.dev/projects/$ID/badge)](https://www.bestpractices.dev/projects/$ID)
 ```
 
 where `$ID` is the ID of your project - you can find it in the URL on the best practices site.

--- a/destf/2023-Q4-progress-report.md
+++ b/destf/2023-Q4-progress-report.md
@@ -1,4 +1,4 @@
-# OpenJS Foundation Projects and the OpenSSF CII Best Practices Badge
+# OpenJS Foundation Projects and the OpenSSF Best Practices Badge
 
 This document is written for two primary audiences: OpenJS Foundation staff/volunteers/stakeholders, and end users of Foundation software projects.
 

--- a/meetings/2023/2023-07-31.md
+++ b/meetings/2023/2023-07-31.md
@@ -23,7 +23,7 @@
 * Having a centralized signing tool for our toolchain [#46](https://github.com/openjs-foundation/security-collab-space/issues/46)
    * Beth - bootstrapping issue, could not justify using sigstore (currently).
    * Node, Technically assets are not signed (diff from mac/win install)
-   * “Signing sha is halfway” and it is required by CII Best practices (silver level) (see: https://github.com/nodejs/security-wg/blob/9c683bd6902560569f5bb019feda5c65335f21ba/tools/ossf_best_practices/silver_criteria.md#secure-release)
+   * “Signing sha is halfway” and it is required by Best practices (silver level) (see: https://github.com/nodejs/security-wg/blob/9c683bd6902560569f5bb019feda5c65335f21ba/tools/ossf_best_practices/silver_criteria.md#secure-release)
    * Matt, incremental approach
    * Beth - https://www.python.org/download/sigstore/
    * Beth - also looking to level up (Slsa level 1) (jenkins does not give provenance in the way GH actions does)

--- a/meetings/2023/2023-08-07.md
+++ b/meetings/2023/2023-08-07.md
@@ -27,7 +27,7 @@
 * Create a prescriptive best practices toolchain [#45](https://github.com/openjs-foundation/security-collab-space/issues/45)
   * Ben will create google doc for collaboration to look at categories and potential tools
 
-* Get Feedback On Draft "OpenSSF CII Best Practices Badge for JS Projects (Ask Ben For Access) [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
+* Get Feedback On Draft "OpenSSF Best Practices Badge for JS Projects (Ask Ben For Access) [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
 
 ## Q&A, Other
 

--- a/meetings/2023/2023-08-14.md
+++ b/meetings/2023/2023-08-14.md
@@ -34,7 +34,7 @@
      * https://github.com/ossf/sbom-everywhere
    * Jordan - will rewrite issue to capture scope as discussed and start work \o/
 
-* Get Feedback On Draft "OpenSSF CII Best Practices Badge for JS Projects" [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
+* Get Feedback On Draft "OpenSSF Best Practices Badge for JS Projects" [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
   * Please get feedback to jordan by end of week!
 
 * Having a centralized signing tool for our toolchain [#46](https://github.com/openjs-foundation/security-collab-space/issues/46)

--- a/meetings/2023/2023-09-11.md
+++ b/meetings/2023/2023-09-11.md
@@ -31,7 +31,7 @@
 * Discuss: Request for Information on Open-Source Software Security: Areas of Long-Term Focus and Prioritization [#53](https://github.com/openjs-foundation/security-collab-space/issues/53)
   * Ben and Robin will put together a draft for the group after Bilbao
 
-* Get Feedback On Draft "OpenSSF CII Best Practices Badge for JS Projects" [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
+* Get Feedback On Draft "OpenSSF Best Practices Badge for JS Projects" [#50](https://github.com/openjs-foundation/security-collab-space/issues/50)
    * Lots of feedback on the doc! One more review prior to publishing. 
    * OpenSSF very interested in upstreaming anything relevant 
 


### PR DESCRIPTION
the Core Infrastructure Initiative ended and was superseded by the OpenSSF in 2020