### PR TITLE
Revise CVE ID handling guidelines in contributor guide

### DIFF
--- a/docs/CNA/cna-guide-for-openjs-cna-contributors.md
+++ b/docs/CNA/cna-guide-for-openjs-cna-contributors.md
@@ -3,12 +3,8 @@
 ## Reserved CVE ID Handling
 
 ### Reserving CVE IDs
-
-- The CNA should have no less than 2 and no more than 5 reserved, unused CVEs at any one time
-- An issue must be created and approved in [security-advisories](https://github.com/openjs-foundation/security-advisories) before additional CVE IDs may be reserved
-
-### Managing Reserved CVE IDs
-- All reserved CVE IDs are stored in [security-advisories](https://github.com/openjs-foundation/security-advisories)/reserved-cve.md until they are assigned to a CVE Request
+CVE IDs shall be reserved on an as-needed basis when a vulnerability determination has been made and public disclosure is expected. 
+Reserved CVE IDs must be either published within 72 hours of public disclosure or rejected if not used. 
 
 ### Assigning a CVE ID to a CVE Request
 - Comment in the CVE Request issue stating which reserved CVE IDs will be requested to be used


### PR DESCRIPTION
I merged an initial commit with the exact same info as the google doc and created a PR for this one so we could have a discussion about changes. In this pr...

Clarified guidelines for reserving and managing CVE IDs based on:

https://www.cve.org/Resources/Roles/Cnas/CNA_Rules_v4.0.pdf

Section 4.2.2