### PR TITLE
Add weekly meeting agenda automation and move to HackMD

### DIFF
--- a/.github/templates/hackmd-agenda-template.md
+++ b/.github/templates/hackmd-agenda-template.md
@@ -3,7 +3,7 @@
 ## Meeting Details
 - **Date**: [DATE]
 - **Time**: 08:30 - 09:30 AM PT
-- **Zoom**: [PLACEHOLDER_ZOOM_LINK]
+- **Zoom**: [Zoom Link]( https://zoom-lfx.platform.linuxfoundation.org/meeting/98301969246?password=889b7578-29b6-4be9-96c1-f74cbce812c4)
 - **Calendar**: https://calendar.openjsf.org
 
 ---
@@ -23,7 +23,6 @@
 ### Issues Labeled `security-agenda`
 [AGENDA_ITEMS]
 
-
 ### Action Items from Previous Meeting
 - [ ] [Review previous action items]
 
@@ -37,11 +36,6 @@
 
 ### [Topic 2]
 [Notes from discussion]
-
-## Q&A, Other
-
-## Next Steps
-- [ ] [Action items with owners and deadlines]
 
 ## Upcoming Meetings
 * **Next Meeting**: [NEXT_MEETING_DATE]

--- a/.github/workflows/weekly-meeting-agenda.yml
+++ b/.github/workflows/weekly-meeting-agenda.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Run every Thursday at 4 PM UTC (9 AM PT / 8 AM PST)
     - cron: "0 16 * * 4"
-  # TODO: Remove push trigger after testing
-  push:
-    branches:
-      - add-meeting-agenda-workflow
   workflow_dispatch:
     inputs:
       meeting_date:
@@ -208,7 +204,7 @@ jobs:
           ## Meeting Details
           - **Date**: ${{ steps.meeting-info.outputs.meeting_date }}
           - **Time**: 08:30 – 09:30 AM PT
-          - **Zoom**: https://zoom-lfx.platform.linuxfoundation.org/meeting/98301969246?password=889b7578-29b6-4be9-96c1-f74cbce812c4
+          - **Zoom**: [Zoom Link]( https://zoom-lfx.platform.linuxfoundation.org/meeting/98301969246?password=889b7578-29b6-4be9-96c1-f74cbce812c4)
           - **Calendar**: [OpenJS Calendar](https://calendar.openjsf.org)
 
           ---


### PR DESCRIPTION
Draft PR For Testing, Will Fix #295 

- Add GitHub Action workflow that runs every Thursday at 4 PM UTC
- Creates HackMD agenda document under team workspace
- Fetches issues labeled 'security-agenda' and adds to agenda
- Creates GitHub issue with meeting details and HackMD link
- Uses 'security-meeting-agenda' label for created issues
- Includes editable HackMD template for customization